### PR TITLE
Makes resolved field optional

### DIFF
--- a/yarn-lock/src/Yarn/Lock/Types.hs
+++ b/yarn-lock/src/Yarn/Lock/Types.hs
@@ -58,7 +58,7 @@ data Keyed a = Keyed (NE.NonEmpty PackageKey) a
 -- | The actual npm package with dependencies and a way to download.
 data Package = Package
   { version              :: Text         -- ^ resolved, specific version
-  , remote               :: Remote
+  , remote               :: Maybe Remote
   , dependencies         :: [PackageKey] -- ^ list of dependencies
   , optionalDependencies :: [PackageKey] -- ^ list of optional dependencies
   } deriving (Eq, Show)

--- a/yarn-lock/tests/TestFile.hs
+++ b/yarn-lock/tests/TestFile.hs
@@ -47,7 +47,7 @@ case_gitRemote = do
           <> hasUid `orEmpty` ("uid", Left ref)
   let gitRemIs parsed (url', ref') = parsed
         <&> T.remote >>= \case
-          T.GitRemote{..} -> do
+          Just T.GitRemote{..} -> do
             assertEqual "url url" url' gitRepoUrl
             assertEqual "url ref" ref' gitRev
           a -> assertFailure ("should be GitRemote, is " <> show a)
@@ -67,13 +67,13 @@ case_fileRemote = do
           [ ("resolved", Left $ "https://gnu.org/stallmanstoe") ]
   astToPackageSuccess good
     <&> T.remote >>= \case
-      T.FileRemote{..} -> do
+      Just T.FileRemote{..} -> do
         assertEqual "remote url" "https://gnu.org/stallmanstoe" fileUrl
         assertEqual "file sha" sha fileSha1
       a -> assertFailure ("should be FileRemote, is " <> show a)
   astToPackageSuccess goodNoIntegrity
     <&> T.remote >>= \case
-      T.FileRemoteNoIntegrity{..} -> assertEqual "remote url" "https://gnu.org/stallmanstoe" fileNoIntegrityUrl
+      Just T.FileRemoteNoIntegrity{..} -> assertEqual "remote url" "https://gnu.org/stallmanstoe" fileNoIntegrityUrl
       a -> assertFailure ("should be FileRemote, is " <> show a)
 
 case_fileLocal :: Assertion
@@ -86,13 +86,13 @@ case_fileLocal = do
           , Left $ "file:../extensions/jupyterlab-toc-0.6.0.tgz") ]
   astToPackageSuccess good
     <&> T.remote >>= \case
-      T.FileLocal{..} -> do
+      Just T.FileLocal{..} -> do
         assertEqual "file path" "../extensions/jupyterlab-toc-0.6.0.tgz" fileLocalPath
         assertEqual "file sha" "393fe" fileLocalSha1
       a -> assertFailure ("should be FileLocal, is " <> show a)
   astToPackageSuccess goodNoIntegrity
     <&> T.remote >>= \case
-      T.FileLocalNoIntegrity{..} -> do
+      Just T.FileLocalNoIntegrity{..} -> do
         assertEqual "file path" "../extensions/jupyterlab-toc-0.6.0.tgz" fileLocalNoIntegrityPath
       a -> assertFailure ("should be FileLocal, is " <> show a)
 
@@ -101,7 +101,7 @@ case_localdir = do
   let good = minimalAst $ []
   astToPackageSuccessWithKey sampleKeyWithDir good
     <&> T.remote >>= \case
-      T.DirectoryLocal {..} -> do
+      Just T.DirectoryLocal {..} -> do
         assertEqual "local directory path" "./mock-dir" dirLocalPath
       a -> assertFailure ("should be FileLocal, is " <> show a)
 
@@ -110,7 +110,7 @@ case_symlinked_dir = do
   let good = minimalAst $ []
   astToPackageSuccessWithKey sampleKeyWithSymDir good
     <&> T.remote >>= \case
-      T.DirectoryLocalSymLinked {..} -> do
+      Just T.DirectoryLocalSymLinked {..} -> do
         assertEqual "local directory path" "./mock-sym-dir" dirLocalSymPath
       a -> assertFailure ("should be DirectoryLocalSymLinked, is " <> show a)
 
@@ -118,7 +118,7 @@ case_missingField :: Assertion
 case_missingField = do
   astToPackageFailureWith
     (File.MissingField "version"
-     NE.:| [File.UnknownRemoteType]) (emptyAst [])
+     NE.:| []) (emptyAst [])
 
 astToPackageSuccessWithKey :: NE.NonEmpty T.PackageKey -> Parse.PackageFields -> IO T.Package
 astToPackageSuccessWithKey key ast = case File.astToPackage key ast of


### PR DESCRIPTION
## Overview

Per yarn's implementation "resolved" field of yarn.lock file is [optional](https://github.com/yarnpkg/yarn/blob/master/src/lockfile/index.js#L45) and can be missing. 

This PR, addresses exception thrown when resolved field is missing, and package is neither local or symbolic directory. 

This is prerequisite to fix: https://github.com/fossas/team-analysis/issues/845

## Testing

1. Create yarn.lock file for simple node project
2. Remove resolved field from one of the entry
3. Replace following method in `src/Strategy/Node/YarnV1/YarnLock.hs`:
```
getLocations :: Maybe YL.Remote -> [Text]
getLocations = \case
  Just (YL.FileRemote url _) -> [url]
  Just (YL.FileRemoteNoIntegrity url) -> [url]
  Just (YL.GitRemote url rev) -> [url <> "@" <> rev]
  Just (YL.DirectoryLocal dirpath) -> [dirpath]
  Just (YL.DirectoryLocalSymLinked dirpath) -> [dirpath]
  _ -> []

```
4. Update yarnlock source package:
```
-- Current implementation of yarn-lock throws runtime error, as described by patches:
-- (a) https://github.com/Profpatsch/yarn2nix/pull/73
-- (b) https://github.com/Profpatsch/yarn2nix/pull/72
-- TODO: Remove once, both PRs are merged. 
source-repository-package
  type: git
  location: https://github.com/fossas/yarn2nix
  tag: 276fb494a22bbc50634a8ff8911d6b53782ab1ed -- <- commit of this PR
  subdir: yarn-lock
```
5. Rebuild fossa-cli by: `make install-dev`
6. Analyze this project using `fossa-dev analyze -o | jq` (it should complete without any errors)